### PR TITLE
Fix weird quotes being inserted into link

### DIFF
--- a/index.html
+++ b/index.html
@@ -139,7 +139,7 @@
                 <p>When using Hyperium, the client and integrated mods send a few small pieces of information to a remote server in exchange for a temporary token for accessing data from Hypixel. This information includes your Minecraft UUID and username, Minecraft Version, Client Version and specific mod being used. This information is processed and used to determine if the client is out of date or if the client should abort the startup procedure<p>
 
                 <h3>What we do with the data</h3>
-                <p>The data is stored securely for analytic purposes. <b>We will never sell or release the data collected from specific users.</b> All analytic graphs may be viewed on <a href=”https://sk1er.club/graphs/hyperium”> sk1er.club/graphs/hyperium </a></p>
+                <p>The data is stored securely for analytic purposes. <b>We will never sell or release the data collected from specific users.</b> All analytic graphs may be viewed on <a href="https://sk1er.club/graphs/hyperium"> sk1er.club/graphs/hyperium </a></p>
 
 
 


### PR DESCRIPTION
Replaced `”` with `"` so the link doesn't go to https://hyperium.cc/"https://sk1er.club/graphs/hyperium"