### PR TITLE
Add support for ‘www.hyperium.cc’

### DIFF
--- a/CNAME
+++ b/CNAME
@@ -1,1 +1,2 @@
 hyperium.cc
+www.hyperium.cc


### PR DESCRIPTION
This way, www.hyperium.cc will redirect to the main site instead of 404ing. 
@CoalCoding 